### PR TITLE
Fix to use `os.environ["..."]` rather than "$...$"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ path and not relative to your home directory).
 3. Insert the following lines:
 ```
 python
-import sys
-sys.path.insert(0, "$DRAKE_GDB_ROOT$")
+import sys, os
+sys.path.insert(0, os.environ["DRAKE_GDB_ROOT"])
 import drake_gdb 
 drake_gdb.register_printers()
 end
 ```
 
-Simply launch gdb and the pretty printers will be instantiated.
+Simply launch gdb and the pretty printers will be instantiated. You should see
+the following output in the GDB terminal:
+```
+Registered GDB printers for Drake
+(gdb)
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project provides a number of debugging utilities for working with drake.
 
 ## Install
 
-1. Install the repository to some path: $DRAKE_GDB_ROOT$ (such that this is the *full* 
+1. Install the repository to some path: `$DRAKE_GDB_ROOT$` (such that this is the *full* 
 path and not relative to your home directory).
 2. Create (if it doesn't already exist) the file `~/.gdbinit`
 3. Insert the following lines:
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
 printing the values of `vec_d`, `vecx_d`, `xform_d`, `mat_d`, and `q_d`, respectively, *without*
 `drake_gdb` looks like this in the command line:
 
-```
+```c++
 $1 = {<Eigen::PlainObjectBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >> = {<Eigen::MatrixBase<Eigen::Matrix<d
 ouble, 3, 1, 0, 3, 1> >> = {<Eigen::DenseBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >> = {<Eigen::DenseCoeff
 sBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0, 3
@@ -108,7 +108,7 @@ ta fields>}}
 
 For the `VectorX` (indicated by `$2`), the vector values aren't displayed at all. *With* `drake_gdb`, it looks like this:
 
-```
+```c++
 $1 = Eigen::Matrix<double, 3, 1, ColMajor> (data ptr: 0x7fffffffdbb8)
 	1.234    
 	5.678    

--- a/drake_gdb.py
+++ b/drake_gdb.py
@@ -14,4 +14,5 @@ def register_printers():
     eigen_printers.register_printers(FOR_CLION)
     identifier.register_printers(FOR_CLION)
     type_safe_index.register_printers(FOR_CLION)
-    
+    print("Registered GDB printers for Drake")
+


### PR DESCRIPTION
Tried out `~/.gdbinit` code as-is, but kept on getting an error such as:
```
AttributeError: module 'drake_gdb' has no attribute 'register_printers'
/home/eacousineau/.gdbinit:6: Error in sourced command file:
Error while executing Python code.
```

It worked on my machine after I used `os.environ[]` instead.

I also added a feedback - that's useful to me for checking if the printers were actually registered. (I believe you should be able to see the output in CLion.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seancurtis-tri/drake_gdb/1)
<!-- Reviewable:end -->
