### PR TITLE
Fix detecting CLion execution by using os.getenv("_") (which should c…

### DIFF
--- a/drake_gdb.py
+++ b/drake_gdb.py
@@ -1,9 +1,8 @@
-import sys
+import sys, os
 
-# This is a *very* brittle mechanism for detecting clion vs. command-line gdb
-# execution. CLion 2016.3.5 runs python version 2.7 and the command-line gdb
-# runs version 3. In the future, if CLion upgrades, this will fail.
-FOR_CLION = sys.version_info[0] == 2
+# This is a brittle mechanism for detecting clion vs. command-line gdb
+# execution. Tested on CLion 2018.3.
+FOR_CLION = "clion" in os.getenv("_", "")
 
 import eigen_printers
 import identifier
@@ -14,4 +13,4 @@ def register_printers():
     eigen_printers.register_printers(FOR_CLION)
     identifier.register_printers(FOR_CLION)
     type_safe_index.register_printers(FOR_CLION)
-    
+


### PR DESCRIPTION
…ontain "clion")

See also https://github.com/SeanCurtis-TRI/drake_gdb/issues/2 and
https://unix.stackexchange.com/questions/292991/usage-of-as-an-environment-variable-passed-to-a-command?rq=1